### PR TITLE
Fix broken doi/zenodo link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ Physical Activity Analysis Toolbox (PAAT)
 =========================================
 
     **Note:** This package is currently under development and the API might change
-    anytime! For reproducible versions, see `zenodo <https://doi.org/10.5281/zenodo.13885706>`_.
+    anytime! For reproducible versions, see `zenodo <https://doi.org/10.5281/zenodo.13885749>`_.
 
 
 .. image:: https://github.com/Trybnetic/paat/actions/workflows/python-test.yml/badge.svg


### PR DESCRIPTION
Hey!

I found a broken link in the README and replaced it with the DOI/zenodo link from the badge.

Not sure whether this is the proper replacement -- this PR is mainly about reporting the broken link :wink: .

Kind regards from Berlin,
Jonas